### PR TITLE
chore: application.yml import 설정 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,3 @@ out/
 
 ### VS Code ###
 .vscode/
-
-application.yml

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,4 @@
+spring:
+  config:
+    import:
+      - classpath:/secret/application.yml


### PR DESCRIPTION
## 코드 설명

- gitignore 설정에서 application.yml 제거
- resources/application.yml 에 resources/secret/application.yml을 import 하도록 설정

<br><br>

## 공유사항

- 아서가 개발해준 백엔드 로그인 API 활용을 위해 해당 브랜치로 체크아웃 하고 기동 시도함.
- secret-key 값이 없다며 스프링부트 로딩 실패
- secret내 application.yml에 값이 존재하지만, resources/application.yml 이 없어서 연동이 되지 않고 있는 상태였음
- 윈도우 이슈일 수도 있음.. resources/secret/application.yml 만 있을 경우 애플리케이션이 기동 되지 않고 있는 이슈임

<br><br>
